### PR TITLE
feat: rename release branch from `next` to `release`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Sharable configuration for [semantic release](https://semantic-release.gitbook.i
 
 Currently, this config is only a slight modification of the default config:
 
-- Deploy from `next` branch instead of `master`
+- Deploy from `release` branch instead of `master`
 - Add [@semantic-release/git](https://github.com/semantic-release/git) plugin to publish updated `package.json` to repository after deployment
 
 ## Installation

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  branch: "next",
+  branch: "release",
   plugins: [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
BREAKING CHANGE: Please use the branch `release` instead of `next` to
trigger a release.